### PR TITLE
Fix non-default-version templated resources and add tools for programmatic resource access

### DIFF
--- a/.github/workflows/daily-upstream-test.yml
+++ b/.github/workflows/daily-upstream-test.yml
@@ -1,0 +1,85 @@
+name: Daily Upstream Documentation Test
+
+on:
+  schedule:
+    # Run daily at 9:00 AM UTC
+    - cron: '0 9 * * *'
+  # Allow manual triggering for testing
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Run tests against upstream docs
+        run: npm test
+
+  create-issue:
+    runs-on: ubuntu-latest
+    needs: test
+    if: failure()
+
+    steps:
+      - name: Create issue for test failure
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '⚠️ Daily upstream documentation test failed';
+            const body = `The daily test against upstream MCP documentation has failed.
+
+            **Date:** ${new Date().toISOString().split('T')[0]}
+            **Workflow Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            This likely means that the upstream MCP documentation has changed in a way that breaks our URL matching tests.
+
+            ## Next Steps
+            1. Review the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) to see which tests failed
+            2. Check the upstream MCP documentation for changes
+            3. Update the test expectations or URL matching logic as needed
+            4. Close this issue once resolved
+
+            ---
+            _This issue was automatically created by the daily upstream test workflow._`;
+
+            // Check if there's already an open issue about this
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'upstream-test-failure',
+            });
+
+            // Only create a new issue if one doesn't already exist
+            if (issues.data.length === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['upstream-test-failure', 'automated'],
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+.claude/settings.local.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.4",
         "node-fetch": "^3.3.2",
-        "typescript": "^5.8.2"
+        "typescript": "^5.8.2",
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.24.6"
       },
       "bin": {
         "mcp-advisor": "dist/index.js"
@@ -1445,18 +1447,18 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.4",
     "node-fetch": "^3.3.2",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
     "@types/node": "^22.13.14",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,23 @@
 #!/usr/bin/env node
 // List of supported versions
-export const SUPPORTED_VERSIONS = ['draft', '2024-11-05', '2025-03-26', '2025-06-18'];
+export const SUPPORTED_VERSIONS = ['draft', '2024-11-05', '2025-03-26', '2025-06-18'] as const;
+type SupportedVersion = typeof SUPPORTED_VERSIONS[number];
+
+// Helper function to check if a string is a supported version
+function isSupportedVersion(version: string): version is SupportedVersion {
+  return (SUPPORTED_VERSIONS as readonly string[]).includes(version);
+}
 
 // Default version to use when no specific version is requested
 // Can be overridden with DEFAULT_SPEC_VERSION environment variable
 const DEFAULT_VERSION = '2025-06-18';
 export const VERSION = (() => {
   const envVersion = process.env.DEFAULT_SPEC_VERSION;
-  if (envVersion && !SUPPORTED_VERSIONS.includes(envVersion)) {
+  if (envVersion && !isSupportedVersion(envVersion)) {
     console.error(`ERROR: Unsupported version '${envVersion}' specified in DEFAULT_SPEC_VERSION environment variable. Supported versions are: ${SUPPORTED_VERSIONS.join(', ')}. Falling back to default version: ${DEFAULT_VERSION}`);
   }
-  return envVersion && SUPPORTED_VERSIONS.includes(envVersion) 
-    ? envVersion 
+  return envVersion && isSupportedVersion(envVersion)
+    ? envVersion
     : DEFAULT_VERSION;
 })();
 
@@ -121,7 +127,7 @@ const GetResourceSchema = z.object({
 });
 
 const GetSpecificationResourceSchema = z.object({
-  version: z.enum(['draft', '2024-11-05', '2025-03-26', '2025-06-18']).describe("MCP specification version to fetch"),
+  version: z.enum(SUPPORTED_VERSIONS).describe("MCP specification version to fetch"),
   section: z.enum(['complete', 'architecture', 'basic', 'utilities', 'server', 'client', 'schema']).optional().describe("Specific section to fetch (defaults to 'complete' which includes all sections)"),
 });
 
@@ -190,7 +196,7 @@ server.setRequestHandler(GetPromptRequestSchema, async (request) => {
   let promptVersion = VERSION;
   if (request.params.arguments?.version) {
     const requestedVersion = request.params.arguments.version;
-    if (!SUPPORTED_VERSIONS.includes(requestedVersion)) {
+    if (!isSupportedVersion(requestedVersion)) {
       throw new McpError(
         ErrorCode.InvalidParams,
         `Unsupported version: '${requestedVersion}'. Supported versions are: ${SUPPORTED_VERSIONS.join(', ')}`
@@ -845,7 +851,7 @@ export function extractVersionFromUri(uri: string): string {
   const versionMatch = uri.match(/\/specification\/([^/]+)\//);
   if (versionMatch && versionMatch[1]) {
     // Validate that the version is supported
-    if (SUPPORTED_VERSIONS.includes(versionMatch[1])) {
+    if (isSupportedVersion(versionMatch[1])) {
       version = versionMatch[1];
     } else {
       console.error(`ERROR: Unsupported version '${versionMatch[1]}' requested in URI: ${uri}`);
@@ -946,7 +952,7 @@ async function fetchResourceContentByUri(uri: string): Promise<ContentItem[]> {
 // Modified getSchema function to accept a version parameter
 export async function getSchemaForVersion(version: string): Promise<any> {
   // Validate that the version is supported
-  if (!SUPPORTED_VERSIONS.includes(version)) {
+  if (!isSupportedVersion(version)) {
     console.error(`ERROR: Unsupported version '${version}' requested for schema`);
     throw new McpError(
       ErrorCode.InvalidParams,

--- a/src/index.ts
+++ b/src/index.ts
@@ -376,13 +376,33 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const resourceContent = await fetchResourceContentByUri(uri);
 
-      // Return the resource content as resource references
-      return {
-        content: resourceContent.map((resource: ContentItem) => ({
-          type: 'resource' as const,
-          resource: resource
-        }))
-      };
+      // Combine multiple content items into text for tool response
+      if (resourceContent.length === 1) {
+        // Single resource - return as text
+        const item = resourceContent[0];
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: item.text || item.blob || ''
+            }
+          ]
+        };
+      } else {
+        // Multiple resources - combine into one text response
+        const combinedText = resourceContent
+          .map(item => `# ${item.name}\n\n${item.text || ''}`)
+          .join('\n\n---\n\n');
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: combinedText
+            }
+          ]
+        };
+      }
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       throw new McpError(
@@ -411,13 +431,33 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const resourceContent = await fetchResourceContentByUri(uri);
 
-      // Return the resource content as resource references
-      return {
-        content: resourceContent.map((resource: ContentItem) => ({
-          type: 'resource' as const,
-          resource: resource
-        }))
-      };
+      // Combine multiple content items into text for tool response
+      if (resourceContent.length === 1) {
+        // Single resource - return as text
+        const item = resourceContent[0];
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: item.text || item.blob || ''
+            }
+          ]
+        };
+      } else {
+        // Multiple resources - combine into one text response
+        const combinedText = resourceContent
+          .map(item => `# ${item.name}\n\n${item.text || ''}`)
+          .join('\n\n---\n\n');
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: combinedText
+            }
+          ]
+        };
+      }
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       throw new McpError(
@@ -528,12 +568,6 @@ const resources = [
   
   // Additional Documentation Resources
   {
-    name: 'MCP Getting Started',
-    uri: 'https://modelcontextprotocol.io/quickstart/index.md',
-    mimeType: 'text/markdown',
-    description: 'Getting started guides for client developers, server developers, and users'
-  },
-  {
     name: 'MCP Development',
     uri: 'https://modelcontextprotocol.io/development/index.md',
     mimeType: 'text/markdown',
@@ -579,15 +613,9 @@ const resources = [
   },
   {
     name: 'MCP Debugging Tools',
-    uri: 'https://modelcontextprotocol.io/legacy/tools/index.md',
+    uri: 'https://modelcontextprotocol.io/docs/tools/index.md',
     mimeType: 'text/markdown',
     description: 'Debugging tools including the MCP Inspector'
-  },
-  {
-    name: 'MCP Overview',
-    uri: 'https://modelcontextprotocol.io/overview/index.md',
-    mimeType: 'text/markdown',
-    description: 'High-level overview of the Model Context Protocol'
   }
 ];
 
@@ -638,12 +666,8 @@ export async function fetchLinksList(): Promise<string[]> {
 
 // Helper function to filter URLs by section and version
 export function filterUrlsBySection(links: string[], section: string, version: string = VERSION): string[] {
-  // Skip empty links and "MCP" entries, and filter to match specified version only
-  const validLinks = links.filter(url => 
-    url && 
-    url !== 'MCP' && 
-    (url.includes(`/${version}/`) || !url.match(/\/20\d{2}-\d{2}-\d{2}\/|\/draft\//))
-  );
+  // Skip empty links and "MCP" entries
+  const validLinks = links.filter(url => url && url !== 'MCP');
 
   // Handle regex patterns
   if (section.startsWith('^')) {
@@ -667,8 +691,31 @@ export function filterUrlsBySection(links: string[], section: string, version: s
     });
   }
 
-  // Default case: match by section path
-  return validLinks.filter(url => url.includes(section));
+  // For versioned spec URLs: First try direct match, then try version replacement
+  const versionPattern = /\/((?:draft|\d{4}-\d{2}-\d{2}))\//;
+
+  // Get all URLs matching the section
+  const sectionMatches = validLinks.filter(url => url.includes(section));
+
+  // Separate versioned URLs from non-versioned URLs
+  const versionedUrls = sectionMatches.filter(url => versionPattern.test(url));
+  const nonVersionedUrls = sectionMatches.filter(url => !versionPattern.test(url));
+
+  // For versioned URLs, try direct match first
+  const directMatches = versionedUrls.filter(url => url.includes(`/${version}/`));
+
+  if (directMatches.length > 0) {
+    return directMatches;
+  }
+
+  // If no direct matches, replace version in all versioned URLs
+  const templatedUrls = versionedUrls.map(url => url.replace(versionPattern, `/${version}/`));
+
+  // Return non-versioned URLs as-is, plus templated versioned URLs
+  const combined = [...nonVersionedUrls, ...templatedUrls];
+
+  // Remove duplicates
+  return [...new Set(combined)];
 }
 
 server.setRequestHandler(ListResourcesRequestSchema, async () => {
@@ -678,7 +725,7 @@ server.setRequestHandler(ListResourcesRequestSchema, async () => {
 });
 
 // Helper function to fetch Markdown content from a URL
-async function fetchMarkdownContent(url: string): Promise<string> {
+async function fetchMarkdownContent(url: string): Promise<string | null> {
   const cached = Cache.get<string>(url);
   if (cached) {
     return cached;
@@ -687,13 +734,19 @@ async function fetchMarkdownContent(url: string): Promise<string> {
   try {
     const fetch = (await import('node-fetch')).default;
     const response = await fetch(url);
-    
+
     if (!response.ok) {
+      // Return null for 404s - these URLs don't exist for this version
+      if (response.status === 404) {
+        console.error(`URL not found (404): ${url}`);
+        return null;
+      }
+      // Throw for other errors
       throw new Error(`HTTP error! Status: ${response.status}`);
     }
-    
+
     let markdown = await response.text();
-    
+
     // Process front matter if it exists
     if (markdown.startsWith('---')) {
       const secondDash = markdown.indexOf('---', 3);
@@ -702,18 +755,17 @@ async function fetchMarkdownContent(url: string): Promise<string> {
         markdown = markdown.substring(secondDash + 3).trim();
       }
     }
-    
+
     // Add source URL as reference
     markdown = markdown + '\n\n---\n*Source: [' + url + '](' + url + ')*\n';
-    
+
     Cache.set(url, markdown);
     return markdown;
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`Error fetching content from ${url}:`, error);
-    
-    // For markdown content, we don't use expired cache on error
-    // Instead return an error message that can be displayed
+
+    // For non-404 errors, return an error message that can be displayed
     return `**Error:** Failed to load content from ${url}: ${errorMessage}`;
   }
 }
@@ -721,7 +773,9 @@ async function fetchMarkdownContent(url: string): Promise<string> {
 // Define a type for content items
 interface ContentItem {
   uri: string;
-  text: string;
+  name?: string;
+  text?: string;
+  blob?: string;
   mimeType: string;
 }
 
@@ -729,20 +783,36 @@ async function getCompleteResourceDoc(baseUri: string, version: string = VERSION
   try {
     // Get the schema first for the specified version
     const schema = await getSchemaForVersion(version);
-    
-    // Get all links and filter for specification URLs matching the specified version
+
+    // Get all links and filter for specification URLs
     const allLinks = await fetchLinksList();
-    const specLinks = allLinks.filter(url => 
-      url.includes(`/specification/${version}/`) && 
-      !url.includes('schema.json')  // Exclude schema.json as we handle it separately
+    const versionPattern = /\/((?:draft|\d{4}-\d{2}-\d{2}))\//;
+
+    // First try direct match with requested version
+    let specLinks = allLinks.filter(url =>
+      url.includes(`/specification/${version}/`) &&
+      !url.includes('schema.json')
     );
-    
+
+    // If no direct matches, find URLs with ANY version and replace
+    if (specLinks.length === 0) {
+      const templateLinks = allLinks.filter(url =>
+        url.includes('/specification/') &&
+        versionPattern.test(url) &&
+        !url.includes('schema.json')
+      );
+      specLinks = templateLinks.map(url => url.replace(versionPattern, `/${version}/`));
+      // Remove duplicates
+      specLinks = [...new Set(specLinks)];
+    }
+
     // Create array to hold multiple contents
     const contents: ContentItem[] = [];
     
     // Add the schema as the first content
     contents.push({
       uri: `${baseUri}#schema`,
+      name: `MCP Specification Schema (${version})`,
       text: JSON.stringify(schema, null, 2),
       mimeType: 'application/json'
     });
@@ -756,31 +826,40 @@ async function getCompleteResourceDoc(baseUri: string, version: string = VERSION
       'server',
       'server/utilities'
     ];
-    
+
     // Fetch and combine content for each section
     for (const section of sections) {
-      const sectionLinks = filterUrlsBySection(specLinks, `/${section}/`);
-      
+      const sectionLinks = filterUrlsBySection(specLinks, `/${section}/`, version);
+
       // Skip empty sections
       if (sectionLinks.length === 0) continue;
-      
+
       // Fetch content from all URLs in this section
       const contentPromises = sectionLinks.map(url => fetchMarkdownContent(url));
       const sectionContents = await Promise.all(contentPromises);
-      
+
+      // Filter out null values (404s) and empty strings
+      const validContents = sectionContents.filter((content): content is string =>
+        content !== null && content.trim().length > 0
+      );
+
+      // Skip section if no valid content
+      if (validContents.length === 0) continue;
+
       // Add section content
       const sectionTitle = section.split('/').pop() || section;
       let sectionDoc = `# ${sectionTitle.charAt(0).toUpperCase() + sectionTitle.slice(1)}\n\n`;
-      sectionDoc += sectionContents.join('\n\n');
-      
+      sectionDoc += validContents.join('\n\n');
+
       // Add as a separate content item
       contents.push({
         uri: `${baseUri}#${section}`,
+        name: `MCP Specification - ${sectionTitle.charAt(0).toUpperCase() + sectionTitle.slice(1)} (${version})`,
         text: sectionDoc,
         mimeType: 'text/markdown'
       });
     }
-    
+
     return contents;
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -797,14 +876,29 @@ async function getCombinedCompleteResourceDoc(version: string = VERSION): Promis
   try {
     // Get all links and filter for specification URLs matching the specified version
     const allLinks = await fetchLinksList();
-    const specLinks = allLinks.filter(url => 
-      url.includes(`/specification/${version}/`) && 
-      !url.includes('schema.json')  // Exclude schema.json as we handle it separately
+    const versionPattern = /\/((?:draft|\d{4}-\d{2}-\d{2}))\//;
+
+    // First try direct match with requested version
+    let specLinks = allLinks.filter(url =>
+      url.includes(`/specification/${version}/`) &&
+      !url.includes('schema.json')
     );
+
+    // If no direct matches, find URLs with ANY version and replace
+    if (specLinks.length === 0) {
+      const templateLinks = allLinks.filter(url =>
+        url.includes('/specification/') &&
+        versionPattern.test(url) &&
+        !url.includes('schema.json')
+      );
+      specLinks = templateLinks.map(url => url.replace(versionPattern, `/${version}/`));
+      // Remove duplicates
+      specLinks = [...new Set(specLinks)];
+    }
     
     // Build the complete document
     let completeDoc = '# Model Context Protocol Documentation\n\n';
-    
+
     // Define the order of sections
     const sections = [
       'architecture',
@@ -814,24 +908,32 @@ async function getCombinedCompleteResourceDoc(version: string = VERSION): Promis
       'server',
       'server/utilities'
     ];
-    
+
     // Fetch and combine content for each section
     for (const section of sections) {
-      const sectionLinks = filterUrlsBySection(specLinks, `/${section}/`);
-      
+      const sectionLinks = filterUrlsBySection(specLinks, `/${section}/`, version);
+
       // Skip empty sections
       if (sectionLinks.length === 0) continue;
-      
+
       // Fetch content from all URLs in this section
       const contentPromises = sectionLinks.map(url => fetchMarkdownContent(url));
       const contents = await Promise.all(contentPromises);
-      
+
+      // Filter out null values (404s) and empty strings
+      const validContents = contents.filter((content): content is string =>
+        content !== null && content.trim().length > 0
+      );
+
+      // Skip section if no valid content
+      if (validContents.length === 0) continue;
+
       // Add section content
       const sectionTitle = section.split('/').pop() || section;
       completeDoc += `\n\n## ${sectionTitle.charAt(0).toUpperCase() + sectionTitle.slice(1)}\n\n`;
-      completeDoc += contents.join('\n\n');
+      completeDoc += validContents.join('\n\n');
     }
-    
+
     return completeDoc;
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -884,6 +986,7 @@ function getSchemaUrlForVersion(version: string): string {
 // Helper function to fetch resource content by URI
 async function fetchResourceContentByUri(uri: string): Promise<ContentItem[]> {
   const version = extractVersionFromUri(uri);
+  console.error(`fetchResourceContentByUri called with URI: ${uri}, extracted version: ${version}`);
 
   if (uri.match(/\/specification\/[^/]+\/index\.md$/)) {
     // Complete specification
@@ -895,6 +998,7 @@ async function fetchResourceContentByUri(uri: string): Promise<ContentItem[]> {
     const schema = await getSchemaForVersion(version);
     return [{
       uri: uri,
+      name: `MCP Specification JSON Schema (${version})`,
       text: JSON.stringify(schema, null, 2),
       mimeType: 'application/json'
     }];
@@ -902,6 +1006,7 @@ async function fetchResourceContentByUri(uri: string): Promise<ContentItem[]> {
 
   // Other resources - fetch and combine
   const links = await fetchLinksList();
+  console.error(`fetchLinksList returned ${links.length} total links`);
   let urls: string[] = [];
 
   if (uri.match(/\/specification\/[^/]+\/architecture\/index\.md$/)) {
@@ -914,8 +1019,6 @@ async function fetchResourceContentByUri(uri: string): Promise<ContentItem[]> {
     urls = filterUrlsBySection(links, '/server/', version);
   } else if (uri.match(/\/specification\/[^/]+\/client\/index\.md$/)) {
     urls = filterUrlsBySection(links, '/client/', version);
-  } else if (uri === 'https://modelcontextprotocol.io/quickstart/index.md') {
-    urls = filterUrlsBySection(links, '/quickstart/');
   } else if (uri === 'https://modelcontextprotocol.io/development/index.md') {
     urls = filterUrlsBySection(links, '/development/');
   } else if (uri === 'https://modelcontextprotocol.io/sdk/index.md') {
@@ -930,20 +1033,40 @@ async function fetchResourceContentByUri(uri: string): Promise<ContentItem[]> {
     urls = filterUrlsBySection(links, '/docs/getting-started/');
   } else if (uri === 'https://modelcontextprotocol.io/docs/learn/index.md') {
     urls = filterUrlsBySection(links, '/docs/learn/');
-  } else if (uri === 'https://modelcontextprotocol.io/legacy/tools/index.md') {
-    urls = filterUrlsBySection(links, '/legacy/tools/');
-  } else if (uri === 'https://modelcontextprotocol.io/overview/index.md') {
-    urls = filterUrlsBySection(links, '/overview/');
+  } else if (uri === 'https://modelcontextprotocol.io/docs/tools/index.md') {
+    urls = filterUrlsBySection(links, '/docs/tools/');
   } else {
     throw new Error(`Unsupported resource URI: ${uri}`);
   }
 
+  if (urls.length === 0) {
+    console.error(`No URLs found for URI: ${uri}, section pattern used in filterUrlsBySection`);
+    throw new Error(`No content URLs found for resource: ${uri}`);
+  }
+
+  console.error(`Fetching ${urls.length} URLs for ${uri}`);
   const contentPromises = urls.map(url => fetchMarkdownContent(url));
   const contents = await Promise.all(contentPromises);
-  const combinedMarkdown = contents.join('\n\n');
+
+  // Filter out null values (404s) and empty strings
+  const validContents = contents.filter((content): content is string =>
+    content !== null && content.trim().length > 0
+  );
+
+  if (validContents.length === 0) {
+    throw new Error(`No valid content found for resource: ${uri} (all URLs returned 404 or errors)`);
+  }
+
+  const combinedMarkdown = validContents.join('\n\n');
+
+  console.error(`Combined markdown length: ${combinedMarkdown.length}`);
+
+  // Extract a descriptive name from the URI
+  const resourceName = uri.split('/').filter(Boolean).slice(-2).join(' - ').replace('index.md', 'Documentation').replace('.md', '');
 
   return [{
     uri: uri,
+    name: resourceName,
     text: combinedMarkdown,
     mimeType: 'text/markdown'
   }];

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ class Cache {
 }
 
 // Suggested topics
-const TOPIC_COMPLETIONS = ['tools', 'prompts', 'resources', 'roots', 'sampling', 'transports', 'authorization', 'why not just use http?', 'security best practices', 'cancellation', 'progress reporting', 'server utilities', 'client utilities', 'elicitation'];
+const TOPIC_COMPLETIONS = ['tools', 'prompts', 'resources', 'roots', 'sampling', 'transports', 'authorization', 'security best practices', 'cancellation', 'progress reporting', 'server utilities', 'client utilities', 'elicitation'];
 // Include all prompt names here
 const EXPLAIN_PROMPT = 'explain';
 const EVALUATE_SERVER_PROMPT = 'evaluate_server_compliance';
@@ -372,7 +372,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       // Return the resource content as resource references
       return {
-        content: resourceContent.map((resource: any) => ({
+        content: resourceContent.map((resource: ContentItem) => ({
           type: 'resource' as const,
           resource: resource
         }))
@@ -407,7 +407,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       // Return the resource content as resource references
       return {
-        content: resourceContent.map((resource: any) => ({
+        content: resourceContent.map((resource: ContentItem) => ({
           type: 'resource' as const,
           resource: resource
         }))

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,17 +17,21 @@ export const VERSION = (() => {
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { 
-  ServerCapabilities, 
-  GetPromptRequestSchema, 
+import {
+  ServerCapabilities,
+  GetPromptRequestSchema,
   ListPromptsRequestSchema,
   ListResourcesRequestSchema,
   ListResourceTemplatesRequestSchema,
   ReadResourceRequestSchema,
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
   CompleteRequestSchema,
   McpError,
   ErrorCode
 } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 // Generic caching mechanism
 interface CacheEntry<T> {
   data: T;
@@ -148,9 +152,22 @@ const resourceTemplates = [
   }
 ];
 
+// Tool input schemas
+const GetResourceSchema = z.object({
+  uri: z.string().describe("URI of the resource to fetch (e.g., 'https://modelcontextprotocol.io/specification/2025-06-18/index.md')"),
+});
+
+const GetSpecificationResourceSchema = z.object({
+  version: z.enum(['draft', '2024-11-05', '2025-03-26', '2025-06-18']).describe("MCP specification version to fetch"),
+  section: z.enum(['complete', 'architecture', 'basic', 'utilities', 'server', 'client', 'schema']).optional().describe("Specific section to fetch (defaults to 'complete' which includes all sections)"),
+});
+
+const ListAvailableResourcesSchema = z.object({});
+
 const serverCapabilities: ServerCapabilities = {
   prompts: {},
   resources: {},
+  tools: {},
   completions: {},
   resourceTemplates: {}
 };
@@ -345,6 +362,135 @@ server.setRequestHandler(CompleteRequestSchema, async (request) => {
   throw new McpError(
     ErrorCode.InvalidParams,
     `Unknown reference type or argument in completion request`
+  );
+});
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: 'getResource',
+        description: 'Fetch a specific MCP documentation resource by its URI. Use this to retrieve any available resource such as specification sections, tutorials, SDK docs, etc.',
+        inputSchema: zodToJsonSchema(GetResourceSchema)
+      },
+      {
+        name: 'getSpecificationResource',
+        description: 'Fetch MCP specification documentation for a specific version and optional section. This is a convenient way to get specification content without knowing the exact URI.',
+        inputSchema: zodToJsonSchema(GetSpecificationResourceSchema)
+      },
+      {
+        name: 'listAvailableResources',
+        description: 'List all available MCP documentation resources with their URIs, names, and descriptions. Use this to discover what resources are available.',
+        inputSchema: zodToJsonSchema(ListAvailableResourcesSchema)
+      }
+    ]
+  };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  if (name === 'getResource') {
+    const validatedArgs = GetResourceSchema.parse(args);
+    const { uri } = validatedArgs;
+
+    // Find the matching resource
+    const matchingResource = resources.find(r => r.uri === uri);
+
+    if (!matchingResource) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Unknown resource URI: ${uri}. Use listAvailableResources tool to see available resources.`
+      );
+    }
+
+    try {
+      const resourceContent = await fetchResourceContentByUri(uri);
+
+      // Return the resource content as resource references
+      return {
+        content: resourceContent.map((resource: any) => ({
+          type: 'resource' as const,
+          resource: resource
+        }))
+      };
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to fetch resource: ${errorMessage}`
+      );
+    }
+  }
+
+  if (name === 'getSpecificationResource') {
+    const validatedArgs = GetSpecificationResourceSchema.parse(args);
+    const { version, section = 'complete' } = validatedArgs;
+
+    // Build the URI based on version and section
+    let uri: string;
+    if (section === 'schema') {
+      uri = `https://modelcontextprotocol.io/specification/${version}/schema.json`;
+    } else if (section === 'complete') {
+      uri = `https://modelcontextprotocol.io/specification/${version}/index.md`;
+    } else if (section === 'utilities') {
+      uri = `https://modelcontextprotocol.io/specification/${version}/basic/utilities/index.md`;
+    } else {
+      uri = `https://modelcontextprotocol.io/specification/${version}/${section}/index.md`;
+    }
+
+    try {
+      const resourceContent = await fetchResourceContentByUri(uri);
+
+      // Return the resource content as resource references
+      return {
+        content: resourceContent.map((resource: any) => ({
+          type: 'resource' as const,
+          resource: resource
+        }))
+      };
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to fetch specification resource: ${errorMessage}`
+      );
+    }
+  }
+
+  if (name === 'listAvailableResources') {
+    ListAvailableResourcesSchema.parse(args);
+
+    // Build a formatted list of all available resources
+    const resourceList = resources.map(resource => {
+      return `**${resource.name}**\n` +
+             `URI: ${resource.uri}\n` +
+             `Type: ${resource.mimeType}\n` +
+             `Description: ${resource.description}`;
+    }).join('\n\n---\n\n');
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `# Available MCP Documentation Resources\n\n` +
+                `Total resources: ${resources.length}\n\n` +
+                `---\n\n${resourceList}\n\n` +
+                `\n## Resource Templates\n\n` +
+                `The following resource templates are also available:\n\n` +
+                resourceTemplates.map(template =>
+                  `**${template.name}**\n` +
+                  `URI Template: ${template.uriTemplate}\n` +
+                  `Description: ${template.description}`
+                ).join('\n\n---\n\n')
+        }
+      ]
+    };
+  }
+
+  throw new McpError(
+    ErrorCode.MethodNotFound,
+    `Unknown tool: ${name}`
   );
 });
 
@@ -766,6 +912,74 @@ function getSchemaUrlForVersion(version: string): string {
   return `https://raw.githubusercontent.com/modelcontextprotocol/specification/refs/heads/main/schema/${version}/schema.json`;
 }
 
+// Helper function to fetch resource content by URI
+async function fetchResourceContentByUri(uri: string): Promise<ContentItem[]> {
+  const version = extractVersionFromUri(uri);
+
+  if (uri.match(/\/specification\/[^/]+\/index\.md$/)) {
+    // Complete specification
+    return await getCompleteResourceDoc(uri, version);
+  }
+
+  if (uri.match(/\/specification\/[^/]+\/schema\.json$/)) {
+    // Schema
+    const schema = await getSchemaForVersion(version);
+    return [{
+      uri: uri,
+      text: JSON.stringify(schema, null, 2),
+      mimeType: 'application/json'
+    }];
+  }
+
+  // Other resources - fetch and combine
+  const links = await fetchLinksList();
+  let urls: string[] = [];
+
+  if (uri.match(/\/specification\/[^/]+\/architecture\/index\.md$/)) {
+    urls = filterUrlsBySection(links, '/architecture/', version);
+  } else if (uri.match(/\/specification\/[^/]+\/basic\/index\.md$/)) {
+    urls = filterUrlsBySection(links, '/basic/', version);
+  } else if (uri.match(/\/specification\/[^/]+\/basic\/utilities\/index\.md$/)) {
+    urls = filterUrlsBySection(links, '/basic/utilities/', version);
+  } else if (uri.match(/\/specification\/[^/]+\/server\/index\.md$/)) {
+    urls = filterUrlsBySection(links, '/server/', version);
+  } else if (uri.match(/\/specification\/[^/]+\/client\/index\.md$/)) {
+    urls = filterUrlsBySection(links, '/client/', version);
+  } else if (uri === 'https://modelcontextprotocol.io/quickstart/index.md') {
+    urls = filterUrlsBySection(links, '/quickstart/');
+  } else if (uri === 'https://modelcontextprotocol.io/development/index.md') {
+    urls = filterUrlsBySection(links, '/development/');
+  } else if (uri === 'https://modelcontextprotocol.io/sdk/index.md') {
+    urls = filterUrlsBySection(links, '/sdk/');
+  } else if (uri === 'https://modelcontextprotocol.io/tutorials/index.md') {
+    urls = filterUrlsBySection(links, '/tutorials/');
+  } else if (uri === 'https://modelcontextprotocol.io/docs/index.md') {
+    urls = filterUrlsBySection(links, '/docs/');
+  } else if (uri === 'https://modelcontextprotocol.io/community/index.md') {
+    urls = filterUrlsBySection(links, '/community/');
+  } else if (uri === 'https://modelcontextprotocol.io/docs/getting-started/index.md') {
+    urls = filterUrlsBySection(links, '/docs/getting-started/');
+  } else if (uri === 'https://modelcontextprotocol.io/docs/learn/index.md') {
+    urls = filterUrlsBySection(links, '/docs/learn/');
+  } else if (uri === 'https://modelcontextprotocol.io/legacy/tools/index.md') {
+    urls = filterUrlsBySection(links, '/legacy/tools/');
+  } else if (uri === 'https://modelcontextprotocol.io/overview/index.md') {
+    urls = filterUrlsBySection(links, '/overview/');
+  } else {
+    throw new Error(`Unsupported resource URI: ${uri}`);
+  }
+
+  const contentPromises = urls.map(url => fetchMarkdownContent(url));
+  const contents = await Promise.all(contentPromises);
+  const combinedMarkdown = contents.join('\n\n');
+
+  return [{
+    uri: uri,
+    text: combinedMarkdown,
+    mimeType: 'text/markdown'
+  }];
+}
+
 // Modified getSchema function to accept a version parameter
 export async function getSchemaForVersion(version: string): Promise<any> {
   // Validate that the version is supported
@@ -814,155 +1028,15 @@ export async function getSchemaForVersion(version: string): Promise<any> {
 
 server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
   const uri = request.params.uri;
-  
-  // Extract version from URI
-  const version = extractVersionFromUri(uri);
-  
-  // Determine which resource is being requested and select the appropriate URLs
-  let urls: string[] = [];
-  let resourceTitle = '';
-  const mimeType = 'text/markdown';
-  
-  if (uri.match(/\/specification\/[^/]+\/architecture\/index\.md$/)) {
-    // Get all architecture-related links
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/architecture/', version);
-    resourceTitle = 'MCP Specification - Architecture';
-  } else if (uri.match(/\/specification\/[^/]+\/basic\/index\.md$/)) {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/basic/', version);
-    resourceTitle = 'MCP Specification - Base Protocol';
-  } else if (uri.match(/\/specification\/[^/]+\/basic\/utilities\/index\.md$/)) {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/basic/utilities/', version);
-    resourceTitle = 'MCP Specification - Utilities';
-  } else if (uri.match(/\/specification\/[^/]+\/server\/index\.md$/)) {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/server/', version);
-    resourceTitle = 'MCP Specification - Server Features';
-  } else if (uri.match(/\/specification\/[^/]+\/client\/index\.md$/)) {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/client/', version);
-    resourceTitle = 'MCP Specification - Client Features';
-  } else if (uri.match(/\/specification\/[^/]+\/index\.md$/)) {
-    // Return the complete specification using multiple contents pattern
-    try {
-      const contentItems = await getCompleteResourceDoc(uri, version);
-      return {
-        contents: contentItems
-      };
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new McpError(
-        ErrorCode.InternalError,
-        `Could not generate complete specification: ${errorMessage}`
-      );
-    }
-  } else if (uri === 'https://modelcontextprotocol.io/quickstart/index.md') {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/quickstart/');
-    resourceTitle = 'MCP Getting Started';
-  } else if (uri === 'https://modelcontextprotocol.io/development/index.md') {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/development/');
-    resourceTitle = 'MCP Development';
-  } else if (uri === 'https://modelcontextprotocol.io/sdk/index.md') {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/sdk/');
-    resourceTitle = 'MCP SDK Documentation';
-  } else if (uri === 'https://modelcontextprotocol.io/tutorials/index.md') {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/tutorials/');
-    resourceTitle = 'MCP Tutorials & Examples';
-  } else if (uri === 'https://modelcontextprotocol.io/docs/index.md') {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/docs/');
-    resourceTitle = 'MCP General Documentation';
-  } else if (uri === 'https://modelcontextprotocol.io/community/index.md') {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/community/');
-    resourceTitle = 'MCP Community Documentation';
-  } else if (uri === 'https://modelcontextprotocol.io/docs/getting-started/index.md') {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/docs/getting-started/');
-    resourceTitle = 'MCP Getting Started Guide';
-  } else if (uri === 'https://modelcontextprotocol.io/docs/learn/index.md') {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/docs/learn/');
-    resourceTitle = 'MCP Learning Resources';
-  } else if (uri === 'https://modelcontextprotocol.io/legacy/tools/index.md') {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/legacy/tools/');
-    resourceTitle = 'MCP Legacy Tools';
-  } else if (uri === 'https://modelcontextprotocol.io/overview/index.md') {
-    const links = await fetchLinksList();
-    urls = filterUrlsBySection(links, '/overview/');
-    resourceTitle = 'MCP Overview';
-  } else if (uri.match(/\/specification\/[^/]+\/schema\.json$/)) {
-    // Return the schema as JSON
-    try {
-      const schema = await getSchemaForVersion(version);
-      return {
-        contents: [
-          {
-            uri: uri,
-            text: JSON.stringify(schema, null, 2),
-            mimeType: 'application/json'
-          }
-        ]
-      };
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new McpError(
-        ErrorCode.InternalError,
-        `Could not read schema resource: ${errorMessage}`
-      );
-    }
-  } else {
-    throw new McpError(
-      ErrorCode.MethodNotFound,
-      `Unknown resource: ${uri}`
-    );
-  }
-  
-  // We found a supported resource, now fetch and combine the content
+
   try {
-    // Initialize an empty string for the combined markdown
-    let combinedMarkdown = '';
-    
-    // Fetch content from all URLs and combine them
-    const contentPromises = urls.map(async (url, index) => {
-      const content = await fetchMarkdownContent(url);
-      
-      // For all pages except the first one, we want to add a section divider
-      if (index > 0) {
-        const fileName = url.split('/').pop() || '';
-        const sectionName = fileName.replace('.md', '').replace('_index', 'Overview');
-        return `\n\n## ${sectionName}\n\n${content}`;
-      }
-      return content;
-    });
-    
-    // Wait for all content to be fetched
-    const contents = await Promise.all(contentPromises);
-    
-    // Combine all markdown content
-    const contentWithSections = contents.join('\n\n');
-    combinedMarkdown += contentWithSections;
-    
-    // Return the combined content
+    const contentItems = await fetchResourceContentByUri(uri);
     return {
-      contents: [
-        {
-          uri: uri,
-          text: combinedMarkdown,
-          mimeType: mimeType
-        }
-      ]
+      contents: contentItems
     };
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error('Error combining specifications:', error);
+    console.error('Error fetching resource:', error);
     throw new McpError(
       ErrorCode.InternalError,
       `Could not read resource: ${uri} - ${errorMessage}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,17 +333,17 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       {
         name: 'getResource',
-        description: 'Fetch a specific MCP documentation resource by its URI. Use this to retrieve any available resource such as specification sections, tutorials, SDK docs, etc.',
+        description: 'Fetch any MCP documentation resource by its exact URI',
         inputSchema: zodToJsonSchema(GetResourceSchema)
       },
       {
         name: 'getSpecificationResource',
-        description: 'Fetch MCP specification documentation for a specific version and optional section. This is a convenient way to get specification content without knowing the exact URI.',
+        description: 'Fetch MCP specification documentation by version and section',
         inputSchema: zodToJsonSchema(GetSpecificationResourceSchema)
       },
       {
         name: 'listAvailableResources',
-        description: 'List all available MCP documentation resources with their URIs, names, and descriptions. Use this to discover what resources are available.',
+        description: 'List all available MCP documentation resources',
         inputSchema: zodToJsonSchema(ListAvailableResourcesSchema)
       }
     ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ const serverCapabilities: ServerCapabilities = {
 const server = new Server(
   { name: 'mcp-advisor', version: '0.5.1' },
   { capabilities: serverCapabilities,
-    instructions: `Workflow: 1) Use 'explain' prompt for understanding MCP concepts before implementation, 2) Use 'evaluate_server_compliance' prompt to validate existing server code against specification requirements. Always clarify expected spec version and provide the version parameter when working with specific spec releases. Resource templates support version-specific access - use {version} parameter for precise specification targeting. Performance: Content is cached for 1 hour; initial requests may take 5-10 seconds for complete specification fetching. Limitations: Requires network access to modelcontextprotocol.io; falls back to expired cache on network failures. Supported versions: ${SUPPORTED_VERSIONS.join(', ')} (default: ${VERSION}).`
+    instructions: `Workflow: 1) Use 'listAvailableResources' tool to discover available MCP documentation resources, 2) Use 'getSpecificationResource' tool to fetch spec content by version and section (fastest for targeted queries), 3) Use 'getResource' tool to fetch any resource by its exact URI. Version targeting: Always specify version when working with specific releases. Supported versions: ${SUPPORTED_VERSIONS.join(', ')} (default: ${VERSION}). Performance: Content is cached for 1 hour; initial requests may take 5-10 seconds for complete specification fetching. Limitations: Requires network access to modelcontextprotocol.io; falls back to expired cache on network failures.`
   }
 );
 

--- a/src/test-url-matching.ts
+++ b/src/test-url-matching.ts
@@ -17,15 +17,12 @@ async function testUrlMatching() {
     '/specification/',
     
     // Documentation sections
-    '/quickstart/',
     '/development/',
     '/community/',           // NEW: SEP Guidelines, Communication, Governance
     '/docs/getting-started/', // NEW: Introduction
     '/docs/learn/',          // NEW: Architecture, Client/Server Concepts  
     '/docs/concepts/',
     '/docs/tools/',
-    '/legacy/tools/',        // NEW: Inspector
-    '/overview/',            // NEW: Main MCP overview
     '/sdk/',
     '/tutorials/',
     
@@ -314,12 +311,111 @@ async function testUrlMatching() {
     'https://modelcontextprotocol.io/specification/{version}/index.md',
     'https://modelcontextprotocol.io/specification/{version}/schema.json'
   ];
-  
+
   for (const templateUri of templateUris) {
     for (const version of SUPPORTED_VERSIONS) {
       const resolvedUri = templateUri.replace('{version}', version);
       console.log(`Template: ${templateUri} with version ${version} -> ${resolvedUri}`);
     }
+  }
+
+  // Test version-swapping functionality
+  console.log('\n=== TESTING VERSION-SWAPPING FUNCTIONALITY ===');
+  console.log('This tests that we can generate URLs for versions not in llms.txt\n');
+
+  // Find which versions have URLs in llms.txt
+  const versionsInLlms = new Map<string, number>();
+  for (const version of SUPPORTED_VERSIONS) {
+    const count = allUrls.filter(url => url.includes(`/${version}/`)).length;
+    versionsInLlms.set(version, count);
+    console.log(`Version ${version} has ${count} URLs in llms.txt`);
+  }
+
+  // Find a version with URLs (likely 2025-06-18 or latest)
+  const sourceVersion = [...versionsInLlms.entries()]
+    .sort((a, b) => b[1] - a[1])[0][0]; // Version with most URLs
+
+  console.log(`\nUsing ${sourceVersion} as source version (has ${versionsInLlms.get(sourceVersion)} URLs)`);
+
+  // Test swapping to each version
+  let versionSwapTestsPassed = true;
+  for (const targetVersion of SUPPORTED_VERSIONS) {
+    if (targetVersion === sourceVersion) continue;
+
+    console.log(`\nTesting swap from ${sourceVersion} to ${targetVersion}:`);
+
+    // Test client section
+    const clientUrls = filterUrlsBySection(allUrls, '/client/', targetVersion);
+    console.log(`  /client/ section: ${clientUrls.length} URLs`);
+
+    if (clientUrls.length === 0) {
+      console.error(`  ❌ FAIL: No URLs found for ${targetVersion} /client/`);
+      versionSwapTestsPassed = false;
+    } else {
+      // Verify all URLs have the correct version
+      const allHaveCorrectVersion = clientUrls.every(url => url.includes(`/${targetVersion}/`));
+      if (allHaveCorrectVersion) {
+        console.log(`  ✅ PASS: All URLs have correct version ${targetVersion}`);
+        // Show a sample URL
+        console.log(`  Sample: ${clientUrls[0]}`);
+      } else {
+        console.error(`  ❌ FAIL: Some URLs don't have version ${targetVersion}`);
+        versionSwapTestsPassed = false;
+      }
+    }
+
+    // Test server section
+    const serverUrls = filterUrlsBySection(allUrls, '/server/', targetVersion);
+    console.log(`  /server/ section: ${serverUrls.length} URLs`);
+
+    if (serverUrls.length === 0) {
+      console.error(`  ❌ FAIL: No URLs found for ${targetVersion} /server/`);
+      versionSwapTestsPassed = false;
+    } else {
+      const allHaveCorrectVersion = serverUrls.every(url => url.includes(`/${targetVersion}/`));
+      if (allHaveCorrectVersion) {
+        console.log(`  ✅ PASS: All URLs have correct version ${targetVersion}`);
+        console.log(`  Sample: ${serverUrls[0]}`);
+      } else {
+        console.error(`  ❌ FAIL: Some URLs don't have version ${targetVersion}`);
+        versionSwapTestsPassed = false;
+      }
+    }
+  }
+
+  if (versionSwapTestsPassed) {
+    console.log('\n✅ All version-swapping tests passed!');
+  } else {
+    console.error('\n❌ Some version-swapping tests failed!');
+    process.exit(1);
+  }
+
+  // Test that non-versioned URLs aren't affected by version parameter
+  console.log('\n=== TESTING NON-VERSIONED URL HANDLING ===');
+  const nonVersionedSections = ['/community/', '/tutorials/'];
+  let nonVersionedTestsPassed = true;
+
+  for (const section of nonVersionedSections) {
+    const urlsWithDefaultVersion = filterUrlsBySection(allUrls, section, VERSION);
+    const urlsWithDraft = filterUrlsBySection(allUrls, section, 'draft');
+
+    const sameUrls = JSON.stringify(urlsWithDefaultVersion.sort()) === JSON.stringify(urlsWithDraft.sort());
+
+    if (sameUrls && urlsWithDefaultVersion.length > 0) {
+      console.log(`✅ ${section}: Returns same URLs regardless of version (${urlsWithDefaultVersion.length} URLs)`);
+    } else if (urlsWithDefaultVersion.length === 0) {
+      console.log(`⚠️  ${section}: No URLs found (may not exist in llms.txt)`);
+    } else {
+      console.error(`❌ ${section}: Returns different URLs for different versions!`);
+      nonVersionedTestsPassed = false;
+    }
+  }
+
+  if (nonVersionedTestsPassed) {
+    console.log('\n✅ All non-versioned URL tests passed!');
+  } else {
+    console.error('\n❌ Some non-versioned URL tests failed!');
+    process.exit(1);
   }
 }
 

--- a/src/test-url-matching.ts
+++ b/src/test-url-matching.ts
@@ -417,6 +417,108 @@ async function testUrlMatching() {
     console.error('\n❌ Some non-versioned URL tests failed!');
     process.exit(1);
   }
+
+  // Test that filterUrlsBySection consistently returns correct version URLs
+  console.log('\n=== TESTING VERSION CONSISTENCY IN URL GENERATION ===');
+  console.log('Verifying that all generated URLs match the requested version\n');
+
+  let versionConsistencyPassed = true;
+
+  for (const testVersion of SUPPORTED_VERSIONS) {
+    console.log(`Testing version: ${testVersion}`);
+
+    const versionedSections = [
+      '/architecture/',
+      '/basic/',
+      '/client/',
+      '/server/'
+    ];
+
+    for (const section of versionedSections) {
+      const urls = filterUrlsBySection(allUrls, section, testVersion);
+
+      if (urls.length === 0) {
+        console.log(`  ⚠️  ${section}: No URLs found`);
+        continue;
+      }
+
+      // Check that ALL URLs contain the requested version
+      const urlsWithWrongVersion = urls.filter(url => {
+        // Versioned URLs should contain the exact version
+        if (url.includes('/specification/')) {
+          return !url.includes(`/${testVersion}/`);
+        }
+        // Non-versioned URLs are OK
+        return false;
+      });
+
+      if (urlsWithWrongVersion.length === 0) {
+        console.log(`  ✅ ${section}: All ${urls.length} URLs have correct version ${testVersion}`);
+      } else {
+        console.error(`  ❌ ${section}: ${urlsWithWrongVersion.length}/${urls.length} URLs have wrong version!`);
+        urlsWithWrongVersion.forEach(url => {
+          const match = url.match(/\/((?:draft|\d{4}-\d{2}-\d{2}))\//);
+          const foundVersion = match ? match[1] : 'none';
+          console.error(`     Expected /${testVersion}/ but found /${foundVersion}/ in: ${url}`);
+        });
+        versionConsistencyPassed = false;
+      }
+    }
+    console.log('');
+  }
+
+  if (versionConsistencyPassed) {
+    console.log('✅ All version consistency tests passed!');
+  } else {
+    console.error('❌ Some version consistency tests failed!');
+    process.exit(1);
+  }
+
+  // Test that version-swapping generates valid URL patterns
+  console.log('\n=== TESTING VERSION-SWAPPED URL VALIDITY ===');
+  console.log('Verifying that swapped URLs follow expected patterns\n');
+
+  let urlValidityPassed = true;
+  const versionPattern = /\/((?:draft|\d{4}-\d{2}-\d{2}))\//;
+
+  for (const testVersion of SUPPORTED_VERSIONS) {
+    const architectureUrls = filterUrlsBySection(allUrls, '/architecture/', testVersion);
+
+    if (architectureUrls.length === 0) {
+      console.log(`⚠️  Version ${testVersion}: No architecture URLs found`);
+      continue;
+    }
+
+    console.log(`Testing ${testVersion}:`);
+
+    for (const url of architectureUrls) {
+      // Extract version from URL
+      const match = url.match(versionPattern);
+
+      if (!match) {
+        // Non-versioned URLs are fine
+        console.log(`  ℹ️  Non-versioned URL: ${url}`);
+        continue;
+      }
+
+      const urlVersion = match[1];
+
+      if (urlVersion === testVersion) {
+        console.log(`  ✅ ${url}`);
+      } else {
+        console.error(`  ❌ Expected version ${testVersion} but got ${urlVersion}: ${url}`);
+        urlValidityPassed = false;
+      }
+    }
+    console.log('');
+  }
+
+  if (urlValidityPassed) {
+    console.log('✅ All URL validity tests passed!');
+  } else {
+    console.error('❌ Some URL validity tests failed!');
+    process.exit(1);
+  }
 }
 
 async function cleanup() {


### PR DESCRIPTION
Fixes https://github.com/olaservo/mcp-advisor/issues/35
Fixes https://github.com/olaservo/mcp-advisor/issues/49

## Summary
- Implements three new tools for programmatic MCP documentation resource access
- Refactors resource fetching to eliminate ~200+ lines of redundant code
- Improves tool descriptions for better LLM clarity

## New Tools
- **getResource**: Fetch any MCP documentation resource by its exact URI
- **getSpecificationResource**: Fetch MCP specification documentation by version and section
- **listAvailableResources**: List all available MCP documentation resources

## Key Changes
- Added `zod` and `zod-to-json-schema` dependencies for tool schema validation
- Created shared `fetchResourceContentByUri()` helper function
- Simplified tool descriptions to be more concise and action-oriented (60-67% shorter)
- Updated server capabilities to include tools support

## Test Plan
- [x] Build succeeds with TypeScript
- [x] Test tools with MCP-compatible LLM application
- [ ] Verify resource fetching works for all resource types
- [x] Confirm tool descriptions are clear to LLMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)